### PR TITLE
Fix run button with default API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Project Setup
+Run `./setup_env.sh` after cloning to install all dependencies.
+
+
+This repository contains a Flask backend and a React frontend.
+
+## Prerequisites
+Alternatively run `./setup_env.sh` to install everything automatically.
+
+- **Python 3.8+**
+- **Node.js 18+** and **npm**
+
+## Python Environment
+1. Create a virtual environment in the repository root:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+2. Install backend dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Frontend
+1. Install Node dependencies:
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Copy `.env.example` to `.env` and edit the address if your backend runs on a
+   different host or port:
+   ```bash
+   cp frontend/.env.example frontend/.env
+   # edit frontend/.env if needed
+   ```
+3. Start the React development server which automatically loads the variable:
+   ```bash
+   npm start --prefix frontend
+   ```
+
+## Running
+1. Start the Flask backend (from the repository root):
+   ```bash
+   source venv/bin/activate
+   cd backend/src
+   python3 api.py
+   ```
+2. In another terminal, start the React frontend as shown above.
+

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -210,7 +210,9 @@ def run_antivirus():
             f.write(code)
 
         # שלב 3: הרץ עם Python מתוך ה־venv
-        venv_python = "/home/korban/ByteMeProject/backend/venv/bin/python"
+        # virtualenv located in the repository root
+        repo_root = os.path.dirname(os.path.dirname(BASE_DIR))
+        venv_python = os.path.join(repo_root, "venv", "bin", "python")
 
         result = subprocess.run(
             [venv_python, exec_path],

--- a/backend/src/modules/infector.py
+++ b/backend/src/modules/infector.py
@@ -8,13 +8,18 @@ from modules.utils import log_summary
 
 
 INFECTION_MARKER = "#infected"
+TRIGGER_SCRIPT_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "simulation", "trigger_ransom.py")
+)
 INJECTION_CODE = (
     f"{INFECTION_MARKER}\n"
     "import os\n"
-    "os.system('python3 /home/korban/ByteMeProject/backend/src/modules/simulation/trigger_ransom.py')\n"
+    f"os.system('python3 {TRIGGER_SCRIPT_PATH}')\n"
 )
 
-TARGET_DIR = "/home/korban/Desktop/TestInfected"
+TARGET_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "tmp", "TestInfected")
+)
 TARGET_EXTENSIONS = ['.py', '.sh']
 DETECTION_LOG = "/tmp/detection_result.txt"
 
@@ -69,7 +74,9 @@ def scan_and_infect(directory):
                 infect_file(filepath)
 
 def run_student_antivirus():
-    path = "/home/korban/ByteMeProject/backend/src/tmp/student_antivirus.py"
+    path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "tmp", "student_antivirus.py")
+    )
     subprocess.run(["python3", path])
 
 if __name__ == "__main__":

--- a/backend/src/modules/simulation/trigger_ransom.py
+++ b/backend/src/modules/simulation/trigger_ransom.py
@@ -3,7 +3,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 from modules.utils import log_summary
 
 # נתיבים
-PROJECT_ROOT = "/home/korban/ByteMeProject11"
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "ByteMeProject11")
+)
 BYTE_ME_DIR = os.path.join(PROJECT_ROOT, "ByteMe")  # כאן נבנה הפרויקט
 SRC_PATH = os.path.join(BYTE_ME_DIR, "src")
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE=http://127.0.0.1:5000

--- a/frontend/src/components/IDE.jsx
+++ b/frontend/src/components/IDE.jsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from "react";
 import "./IDE.css";
 
+const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
+
 export default function IDE() {
   const [code, setCode] = useState("");
   const [output, setOutput] = useState("");
 
   useEffect(() => {
-    fetch("http://127.0.0.1:5000/antivirus/code")  // חדש
+    fetch(`${API_BASE}/antivirus/code`)  // חדש
       .then(res => res.text())
       .then(text => setCode(text));
   }, []);
@@ -14,14 +16,14 @@ export default function IDE() {
  const runCode = async () => {
   try {
     // שלב 1: שמור את הקוד הנוכחי
-    await fetch("http://127.0.0.1:5000/save-antivirus", {
+    await fetch(`${API_BASE}/save-antivirus`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ code })
     });
 
     // שלב 2: הרץ את הקובץ
-    const res = await fetch("http://127.0.0.1:5000/run-antivirus", {
+    const res = await fetch(`${API_BASE}/run-antivirus`, {
       method: "POST",
     });
     const data = await res.json();

--- a/frontend/src/components/Quiz.jsx
+++ b/frontend/src/components/Quiz.jsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { useNavigate } from "react-router-dom";
 
+const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
+
 const Quiz = () => {
   const navigate = useNavigate();
   const [answers, setAnswers] = useState({});
@@ -125,7 +127,7 @@ const Quiz = () => {
           onClick={() => {
   setSubmitted(true);
 
-  fetch("http://127.0.0.1:5000/progress/quiz", {
+  fetch(`${API_BASE}/progress/quiz`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({

--- a/frontend/src/pages/Practice.js
+++ b/frontend/src/pages/Practice.js
@@ -2,6 +2,8 @@
 import { useState } from 'react';
 import axios from 'axios';
 
+const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
+
 const TASKS = [
   {
     id: 'infection',
@@ -31,14 +33,14 @@ export default function PracticeExercise() {
 
   const submitCode = async () => {
     try {
-      await axios.post('http://127.0.0.1:5000/save-antivirus', { code: studentCode });
-      const res = await axios.post('http://127.0.0.1:5000/run-antivirus');
+      await axios.post(`${API_BASE}/save-antivirus`, { code: studentCode });
+      const res = await axios.post(`${API_BASE}/run-antivirus`);
       const result = res.data.result || res.data.error || 'אין פלט';
       setOutput(result);
       const success = result.includes('הצפנה נבלמה') || result.includes('BLOCKED');
       setSimulationStatus(success ? '✔️ הצלחה' : '❌ כישלון');
 
-      await axios.post('http://127.0.0.1:5000/update-statistics', {
+      await axios.post(`${API_BASE}/update-statistics`, {
         type: currentTask,
         success
       });

--- a/frontend/src/pages/SimulationEncrypt.js
+++ b/frontend/src/pages/SimulationEncrypt.js
@@ -3,13 +3,15 @@ import { Link } from "react-router-dom";
 import "./styles/SimulationEncrypt.css";
 import MatrixBackground from "../components/MatrixBackground";
 
+const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
+
 const SimulationEncrypt = () => {
   const [folder, setFolder] = useState("");
 
   const encrypt = async () => {
     if (!folder) return alert("📁 נא למלא נתיב");
     try {
-      const res = await fetch("http://127.0.0.1:5000/encrypt", {
+      const res = await fetch(`${API_BASE}/encrypt`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ folder })
@@ -58,7 +60,7 @@ const SimulationEncrypt = () => {
         <button
           className="btn bg-green-700 hover:bg-green-800 text-white mt-4"
           onClick={() => {
-            fetch("http://127.0.0.1:5000/decrypt", { method: "POST" })
+            fetch(`${API_BASE}/decrypt`, { method: "POST" })
               .then(res => res.json())
               .then(data => alert(data.message))
               .catch(() => alert("❌ שגיאה בפענוח הקבצים"));

--- a/frontend/src/pages/SimulationInfection.js
+++ b/frontend/src/pages/SimulationInfection.js
@@ -2,14 +2,16 @@ import React from "react";
 import { Link } from "react-router-dom";
 import MatrixBackground from "../components/MatrixBackground";
 
+const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
+
 const SimulationInfection = () => {
   const triggerInfection = async () => {
   try {
     // שלב 1: הרצת האנטי וירוס
-    await fetch("http://127.0.0.1:5000/run-antivirus", { method: "POST" });
+    await fetch(`${API_BASE}/run-antivirus`, { method: "POST" });
 
     // שלב 2: הרצת סימולציית הדבקה
-    const res = await fetch("http://127.0.0.1:5000/infection", { method: "POST" });
+    const res = await fetch(`${API_BASE}/infection`, { method: "POST" });
     const data = await res.json();
 
     alert(data.status || data.error);

--- a/frontend/src/pages/SimulationRansom.js
+++ b/frontend/src/pages/SimulationRansom.js
@@ -1,12 +1,14 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import "./styles/SimulationRansom.css";
+
+const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
 import MatrixBackground from "../components/MatrixBackground";
 
 const SimulationRansom = () => {
   const triggerRansom = async () => {
     try {
-      const res = await fetch("http://127.0.0.1:5000/test-ransom", { method: "POST" });
+      const res = await fetch(`${API_BASE}/test-ransom`, { method: "POST" });
       const data = await res.json();
       alert(data.status || data.error);
     } catch {

--- a/frontend/src/pages/Summary.js
+++ b/frontend/src/pages/Summary.js
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import "./styles/Summary.css";
 
+const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
+
 const Summary = () => {
   const [logs, setLogs] = useState("טוען...");
   
@@ -13,7 +15,7 @@ const Summary = () => {
 });
 
   useEffect(() => {
-    fetch("http://127.0.0.1:5000/summary/logs")
+    fetch(`${API_BASE}/summary/logs`)
       .then((res) => res.json())
       .then((data) => {
         setLogs(data.logs);
@@ -23,7 +25,7 @@ const Summary = () => {
   }, []);
 
   const clearLogs = () => {
-    fetch("http://127.0.0.1:5000/summary/clear", { method: "POST" })
+    fetch(`${API_BASE}/summary/clear`, { method: "POST" })
       .then((res) => res.json())
       .then((data) => {
         if (data.status === "ok") {

--- a/frontend/src/pages/TheoryPage.jsx
+++ b/frontend/src/pages/TheoryPage.jsx
@@ -2,6 +2,8 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 
+const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
+
 const content = [
   { title: "מהי תוכנת כופר?", text: "תוכנת כופר (Ransomware) היא סוג של תוכנה זדונית שמצפינה את הקבצים במחשב הקורבן ודורשת תשלום (בדרך כלל במטבעות קריפטוגרפיים) לשחרורם.", icon: "🔐" },
   { title: "שלב החדירה", text: "הכופרה נכנסת למחשב באמצעות מיילים מזויפים, קבצים נגועים או ניצול פרצות אבטחה.", icon: "📥" },
@@ -35,7 +37,7 @@ useEffect(() => {
     sessionStorage.setItem("visitedTheoryPages", JSON.stringify(updated));
 
     // עדכן שרת
-    fetch("http://127.0.0.1:5000/progress/theory", {
+    fetch(`${API_BASE}/progress/theory`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ page: index + 1 })

--- a/frontend/src/pages/Tools.js
+++ b/frontend/src/pages/Tools.js
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 import { useNavigate } from "react-router-dom";
 import "./styles/Tools.css";
 
+const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
+
 const Tools = () => {
   const [key, setKey] = useState('');
   const navigate = useNavigate();
@@ -10,7 +12,7 @@ const Tools = () => {
 
   const generateKey = async () => {
     try {
-      const res = await fetch("http://127.0.0.1:5000/generate-key");
+      const res = await fetch(`${API_BASE}/generate-key`);
       const data = await res.json();
       setKey(data.key);
     } catch {

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Create Python virtual environment and install backend dependencies
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+
+deactivate
+
+# Install frontend dependencies
+cd frontend
+npm install
+cd ..
+
+echo "Environment setup complete"


### PR DESCRIPTION
## Summary
- document how to use a `.env` file for configuring React
- provide `.env.example`
- default `API_BASE` to `http://127.0.0.1:5000`

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842adc0768c8328a090139329826d78