### PR TITLE
Enhance summary stats with task results

### DIFF
--- a/backend/src/modules/sim_flow.py
+++ b/backend/src/modules/sim_flow.py
@@ -1,16 +1,42 @@
 import os
 import subprocess
 import sys
+from datetime import datetime
 
+import json
 from modules.utils import log_summary
 from modules.constants import DETECTION_FILE, BLOCK_FLAG
 
 MODULE_DIR = os.path.dirname(__file__)
+STATS_FILE = os.path.join(MODULE_DIR, "summary", "stats.json")
 
 SIMULATION_SCRIPTS = {
     "infection": os.path.join(MODULE_DIR, "infector.py"),
     "ransom": os.path.join(MODULE_DIR, "simulation", "trigger_ransom.py"),
 }
+
+def _update_stats(task: str, detected: bool, blocked: bool):
+    """Update summary stats file with task results."""
+    if os.path.exists(STATS_FILE):
+        with open(STATS_FILE, "r", encoding="utf-8") as f:
+            stats = json.load(f)
+    else:
+        stats = {}
+
+    results = stats.get("task_results", {})
+    results[task] = {"detected": detected, "blocked": blocked}
+    stats["task_results"] = results
+
+    # Update simulations_blocked list
+    stats["simulations_blocked"] = [t for t, r in results.items() if r.get("blocked")]
+
+    total = len(results)
+    if total:
+        detected_count = sum(1 for r in results.values() if r.get("detected"))
+        stats["detection_accuracy"] = int(detected_count / total * 100)
+
+    with open(STATS_FILE, "w", encoding="utf-8") as f:
+        json.dump(stats, f, ensure_ascii=False)
 
 def run_simulation(task: str):
     """Run a simulation with detection+blocking logic."""
@@ -18,7 +44,11 @@ def run_simulation(task: str):
     if os.path.exists(DETECTION_FILE):
         os.remove(DETECTION_FILE)
 
+    # Single log entry for starting the simulation
     log_summary(f"[SYSTEM] סימולציית {task} הופעלה", "system")
+    logs = []
+    time_now = lambda: datetime.now().strftime("%H:%M:%S")
+    logs.append({"time": time_now(), "msg": f"סימולציית {task} הופעלה"})
 
 
 
@@ -47,22 +77,35 @@ def run_simulation(task: str):
 
     detected = os.path.exists(DETECTION_FILE) and os.path.getsize(DETECTION_FILE) > 0
     if detected:
-        log_summary(f"[OK] זיהוי הצליח בסימולציית {task}", "success")
+        logs.append({"time": time_now(), "msg": "אנטי וירוס זיהה תהליך חשוד"})
     else:
-        log_summary(f"[FAIL] לא זוהתה הדבקה בזמן בסימולציית {task}", "fail")
+        logs.append({"time": time_now(), "msg": "לא זוהה התהליך החשוד"})
 
     blocked = False
     if detected:
         if os.path.exists(BLOCK_FLAG):
             blocked = True
-            log_summary("[BLOCK] נחסם באמצעות /tmp/block_ransom", "success")
+            logs.append({"time": time_now(), "msg": "התהליך הזדוני נחסם"})
         elif ret == 2:
             blocked = True
-            log_summary("[BLOCK] הסקריפט חזר עם קוד 2 – זוהתה חסימה", "success")
+            logs.append({"time": time_now(), "msg": "התהליך הזדוני נחסם"})
         else:
-            log_summary("[FAIL] תהליך סימולציה לא נחסם בפועל", "fail")
+            logs.append({"time": time_now(), "msg": "חסימה נכשלה"})
     else:
-        log_summary("לא בוצעה חסימה מאחר והאיום לא זוהה", "system")
+        logs.append({"time": time_now(), "msg": "חסימה לא בוצעה"})
+
+    _update_stats(task, detected, blocked)
+
+    # Single summary log entry for this simulation's result
+    if detected and blocked:
+        log_summary(f"[RESULT] סימולציית {task} הצליחה (זוהה ונחסם)", "success")
+        logs.append({"time": time_now(), "msg": "הסימולציה זוהתה ונחסמה"})
+    elif detected and not blocked:
+        log_summary(f"[RESULT] סימולציית {task} זוהתה אך לא נחסמה", "fail")
+        logs.append({"time": time_now(), "msg": "זוהה אך לא נחסם"})
+    else:
+        log_summary(f"[RESULT] סימולציית {task} לא זוהתה", "fail")
+        logs.append({"time": time_now(), "msg": "לא זוהתה"})
 
     return {
         "detected": detected,
@@ -70,4 +113,5 @@ def run_simulation(task: str):
         "stdout": stdout,
         "stderr": stderr,
         "returncode": ret,
+        "logs": logs,
     }

--- a/frontend/src/components/Timeline.jsx
+++ b/frontend/src/components/Timeline.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function Timeline({ logs = [] }) {
+  return (
+    <ul className="border-r-2 border-gray-400 pr-4 space-y-1 text-sm">
+      {logs.map((log, idx) => (
+        <li key={idx} className="flex items-start gap-2">
+          <span className="text-gray-400">{log.time}</span>
+          <span>{log.msg}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/pages/Practice.js
+++ b/frontend/src/pages/Practice.js
@@ -1,5 +1,6 @@
 // עמוד תרגול מעשי - React עם ממשק מותאם אישית (רשימת משימות וחלונית הסבר)
 import { useState } from 'react';
+import Timeline from '../components/Timeline';
 import axios from 'axios';
 
 const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
@@ -44,9 +45,18 @@ export default function PracticeExercise() {
   const [showToolbox, setShowToolbox] = useState(false);
   const [detected, setDetected] = useState(null);
   const [blocked, setBlocked] = useState(null);
+  const [logs, setLogs] = useState([]);
+  const [taskStatus, setTaskStatus] = useState({});
   const [currentTask, setCurrentTask] = useState('infection');
 
   const currentTaskData = TASKS.find(task => task.id === currentTask);
+
+  const getStatusText = status => {
+    if (!status) return '⬜ לא בוצעה';
+    if (status.detected && status.blocked) return '🟢 בוצעה בהצלחה';
+    if (status.detected && !status.blocked) return '🟡 זוהה, לא נחסם';
+    return '⬜ לא בוצעה';
+  };
 
   const runAntivirus = async () => {
     try {
@@ -55,10 +65,12 @@ export default function PracticeExercise() {
       setOutput(res.data.result || res.data.error || '');
       setDetected(null);
       setBlocked(null);
+      setLogs([]);
     } catch {
       setOutput('❌ שגיאה בהרצה');
       setDetected(null);
       setBlocked(null);
+      setLogs([]);
     }
   };
 
@@ -69,10 +81,13 @@ export default function PracticeExercise() {
       setOutput(res.data.stdout || res.data.stderr || '');
       setDetected(res.data.detected);
       setBlocked(res.data.blocked);
+      setLogs(res.data.logs || []);
+      setTaskStatus(prev => ({ ...prev, [currentTask]: { detected: res.data.detected, blocked: res.data.blocked } }));
     } catch {
       setOutput('❌ שגיאה בהרצה');
       setDetected(null);
       setBlocked(null);
+      setLogs([]);
     }
   };
 
@@ -98,16 +113,20 @@ export default function PracticeExercise() {
               setOutput('');
               setDetected(null);
               setBlocked(null);
+              setLogs([]);
             }}
             className={`px-4 py-2 rounded shadow text-white ${currentTask === task.id ? 'bg-blue-600' : 'bg-slate-700 hover:bg-slate-600'}`}
           >
-            {task.label}
+            {task.label} ({getStatusText(taskStatus[task.id])})
           </button>
         ))}
       </div>
 
       {/* תיאור המשימה הנבחרת */}
-      <div className="bg-slate-800 rounded p-4 text-sm">
+      <div className="bg-slate-800 rounded p-4 text-sm space-y-2">
+        <h2 className="text-lg font-semibold">
+          {currentTaskData.label} ({getStatusText(taskStatus[currentTask])})
+        </h2>
         <p><span className="font-bold">🧠 משימה:</span> {currentTaskData.description}</p>
       </div>
 
@@ -141,13 +160,13 @@ export default function PracticeExercise() {
           onClick={runAntivirus}
           className="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded text-lg shadow"
         >
-          ▶️ הרץ אנטי וירוס
+          🛡️ הפעל אנטי־וירוס בלבד
         </button>
         <button
           onClick={runSimulation}
           className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded text-lg shadow"
         >
-          ▶️ הפעל סימולציה
+          🚀 הפעל סימולציה מלאה
         </button>
       </div>
 
@@ -158,11 +177,19 @@ export default function PracticeExercise() {
             {output}
           </pre>
           {detected !== null && (
-            <div className="space-y-1 text-xl">
-              <p>{detected ? '✅ זיהוי הצליח' : '❌ זיהוי נכשל'}</p>
+            <div className={`p-4 rounded space-y-1 text-xl ${detected && blocked ? 'bg-green-900' : 'bg-red-900'}`}> 
+              <p>{detected ? '✅ זיהוי התהליך הצליח!' : '❌ לא זוהה התהליך החשוד.'}</p>
               {detected && (
-                <p>{blocked ? '🔒 חסימה הצליחה' : '🔓 חסימה נכשלה'}</p>
+                <p>{blocked ? '🟢 התהליך הזדוני נחסם בהצלחה!' : '🔴 התהליך הזדוני לא נחסם!'}</p>
               )}
+            </div>
+          )}
+          {logs.length > 0 && (
+            <Timeline logs={logs} />
+          )}
+          {detected !== null && (!detected || (detected && !blocked)) && (
+            <div className="bg-yellow-900 p-2 rounded text-sm">
+              { !detected ? 'הטיפ שלנו: ודא שהאנטי־וירוס שלך סורק תהליכים בזמן אמת.' : 'הטיפ שלנו: צור קובץ חסימה (/tmp/block_ransom) מיד כשזיהית.'}
             </div>
           )}
         </div>

--- a/frontend/src/pages/Summary.js
+++ b/frontend/src/pages/Summary.js
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 import "./styles/Summary.css";
 
+const TASK_LABELS = {
+  infection: "🧬 חסימת הדבקה",
+  encrypt: "🔐 מניעת הצפנה",
+  decrypt: "🗝️ פענוח קבצים",
+};
+
 const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
 
 const Summary = () => {
@@ -11,7 +17,8 @@ const Summary = () => {
   quiz_score: 0,
   simulations_blocked: [],
   detection_accuracy: 0,
-  theory_progress_percent: 0
+  theory_progress_percent: 0,
+  task_results: {}
 });
 
   useEffect(() => {
@@ -61,6 +68,22 @@ const Summary = () => {
               <span>🎯 אחוז דיוק בזיהוי:</span>
               <span>{stats.detection_accuracy}%</span>
             </div>
+            {stats.task_results && (
+              <div className="summaryItem">
+                <span>📋 סטטוס משימות:</span>
+                <ul className="list-disc pr-5">
+                  {Object.entries(TASK_LABELS).map(([id, label]) => {
+                    const res = stats.task_results[id] || {};
+                    let txt = '⬜ לא בוצעה';
+                    if (res.detected && res.blocked) txt = '🟢 בוצעה בהצלחה';
+                    else if (res.detected && !res.blocked) txt = '🟡 זוהה, לא נחסם';
+                    return (
+                      <li key={id}>{label} - {txt}</li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- track task success and detection accuracy in `sim_flow`
- display task result status on Summary page
- streamline simulation log output so only the start and final status are recorded

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68459f1111f48328bd8a878c6f869b8f