### PR TITLE
Introduce kill_process helper for blocking simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,14 @@ Alternatively run `./setup_env.sh` to install everything automatically.
    ```
 2. In another terminal, start the React frontend as shown above.
 
+## Sample Data
+The repository includes a `backend/target` folder used by the encryption
+simulation and example antivirus scripts. A few dummy files are stored there
+so you can easily test the encryption and decryption flows. Infected sample
+files for the infection scenario reside under `backend/tmp/TestInfected`.
+
+## Antivirus Helpers
+Use `modules.tools.kill_process(pid)` in your antivirus script to terminate
+malicious simulations. The function also writes the `/tmp/block_ransom` flag so
+the backend recognizes that the process was blocked.
+

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -183,10 +183,10 @@ def run_infection():
 @app.route("/antivirus/code", methods=["GET"])
 def read_student_code():
     path = os.path.abspath(os.path.join(BASE_DIR, "..", "tmp", "student_antivirus.py"))
-    default_code = f'''with open("{BLOCK_FLAG}", "w") as f:
-    f.write("BLOCKED")
+    default_code = f'''from modules.tools import kill_process
 
-    print("✅ אנטי וירוס הופעל בהצלחה!")'''
+# דוגמה לשימוש: kill_process(1234)
+print("✅ אנטי וירוס הופעל בהצלחה!")'''
     try:
         if not os.path.exists(path) or os.path.getsize(path) == 0:
             with open(path, "w") as f:

--- a/backend/src/modules/constants.py
+++ b/backend/src/modules/constants.py
@@ -1,2 +1,13 @@
+import os
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
 DETECTION_FILE = "/tmp/detection_result.txt"
 BLOCK_FLAG = "/tmp/block_ransom"
+
+# Optional file to store the PID of a running malicious process so
+# student antiviruses can terminate it using tools.kill_process.
+MALWARE_PID_FILE = "/tmp/malware_pid"
+
+# Folder with files used by the encryption/decryption simulation
+TARGET_FOLDER = os.path.join(BASE_DIR, "target")

--- a/backend/src/modules/decrypt.py
+++ b/backend/src/modules/decrypt.py
@@ -3,13 +3,14 @@ from Crypto.Cipher import AES
 from Crypto.Util.Padding import unpad
 from modules.utils import log_action
 from modules.utils import log_summary
+from modules.constants import TARGET_FOLDER
 
 # חייב להיות אותו מפתח קבוע
 KEY = bytes.fromhex("3031323334353637383961626364656630313233343536373839616263646566")
 SIGNATURE = b"BME1"
 CHUNK_SIZE = 10 * 1024
 
-def decrypt_files(folder: str = "./target"):
+def decrypt_files(folder: str = TARGET_FOLDER):
     for root, _, files in os.walk(folder):
         for name in files:
             path = os.path.join(root, name)

--- a/backend/src/modules/encrypt.py
+++ b/backend/src/modules/encrypt.py
@@ -3,7 +3,7 @@ from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 from modules.utils import log_action
 from modules.utils import log_summary
-from modules.constants import DETECTION_FILE
+from modules.constants import DETECTION_FILE, TARGET_FOLDER
 
 
 # מפתח קבוע (32 bytes == 256bit)
@@ -11,7 +11,7 @@ KEY = bytes.fromhex("30313233343536373839616263646566303132333435363738396162636
 SIGNATURE = b"BME1"
 CHUNK_SIZE = 10 * 1024
 
-def encrypt_files(folder: str = "./target"):
+def encrypt_files(folder: str = TARGET_FOLDER):
     open(DETECTION_FILE, "w").close()
 
     for root, _, files in os.walk(folder):

--- a/backend/src/modules/tools/__init__.py
+++ b/backend/src/modules/tools/__init__.py
@@ -1,0 +1,24 @@
+import os
+import signal
+from modules.constants import BLOCK_FLAG
+
+
+def kill_process(pid: int | None = None) -> bool:
+    """Terminate the given process ID (if provided) and mark the block flag."""
+    if pid is not None:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return False
+        except Exception:
+            pass
+
+    # Mark that the ransomware was blocked
+    try:
+        with open(BLOCK_FLAG, "w") as f:
+            f.write("BLOCKED")
+    except Exception:
+        pass
+
+    return True
+

--- a/backend/target/sample.txt
+++ b/backend/target/sample.txt
@@ -1,0 +1,1 @@
+Sample data

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Example Antivirus Scripts
+
+These standalone Python scripts demonstrate simple antivirus behaviors for the practice tasks. They are **not** integrated with the main project and can be run separately.
+
+- `av_infection.py` – scans the sample `backend/tmp/TestInfected` directory for injected code and blocks the threat if found.
+- `av_encrypt.py` – checks files inside `backend/target` for the ransomware signature and blocks encryption attempts.
+- `av_decrypt.py` – decrypts files in `backend/target` that were previously encrypted with the provided key.
+
+Each script writes detection to `/tmp/detection_result.txt` and calls `modules.tools.kill_process` to terminate the malicious process (which also creates `/tmp/block_ransom` for compatibility).

--- a/examples/av_decrypt.py
+++ b/examples/av_decrypt.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Example script for decrypting files encrypted by the simulation."""
+import os
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import unpad
+
+DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend", "target"))
+SIGNATURE = b"BME1"
+KEY = bytes.fromhex("3031323334353637383961626364656630313233343536373839616263646566")
+CHUNK_SIZE = 10 * 1024
+
+
+def decrypt_file(path: str):
+    with open(path, "rb") as f:
+        data = f.read()
+    if not data.startswith(SIGNATURE):
+        return False
+
+    iv = data[4:20]
+    enc_header = data[20:20 + ((CHUNK_SIZE + AES.block_size - 1) // AES.block_size) * AES.block_size]
+    tail = data[20 + len(enc_header):]
+
+    cipher = AES.new(KEY, AES.MODE_CBC, iv)
+    header = unpad(cipher.decrypt(enc_header), AES.block_size)
+
+    with open(path, "wb") as f:
+        f.write(header + tail)
+    print(f"Decrypted {path}")
+    return True
+
+
+def decrypt_all():
+    for root, _, files in os.walk(DATA_DIR):
+        for name in files:
+            decrypt_file(os.path.join(root, name))
+
+
+if __name__ == "__main__":
+    decrypt_all()

--- a/examples/av_encrypt.py
+++ b/examples/av_encrypt.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Standalone antivirus example for detecting ransomware encryption."""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend", "src")))
+
+DETECTION_FILE = "/tmp/detection_result.txt"
+from modules.tools import kill_process
+DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend", "target"))
+SIGNATURE = b"BME1"
+
+
+def scan_and_block():
+    for root, _, files in os.walk(DATA_DIR):
+        for name in files:
+            path = os.path.join(root, name)
+            try:
+                with open(path, "rb") as f:
+                    if f.read(4) == SIGNATURE:
+                        with open(DETECTION_FILE, "w") as d:
+                            d.write("ENCRYPTED")
+                        kill_process()
+                        print(f"Blocked encryption for {path}")
+                        return
+            except Exception:
+                continue
+    print("No encrypted files found.")
+
+
+if __name__ == "__main__":
+    scan_and_block()

--- a/examples/av_infection.py
+++ b/examples/av_infection.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Simple standalone antivirus example for infection detection."""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend", "src")))
+
+DETECTION_FILE = "/tmp/detection_result.txt"
+from modules.tools import kill_process
+TARGET_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend", "tmp", "TestInfected"))
+INFECTION_MARKER = "#infected"
+
+
+def scan_and_block():
+    detected = False
+    for root, _, files in os.walk(TARGET_DIR):
+        for name in files:
+            path = os.path.join(root, name)
+            try:
+                with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                    if INFECTION_MARKER in f.read():
+                        print(f"Suspicious code found in {path}")
+                        detected = True
+                        break
+            except Exception:
+                continue
+        if detected:
+            break
+
+    if detected:
+        with open(DETECTION_FILE, "w") as f:
+            f.write("INFECTED")
+        # Assume the malicious process ID was provided externally
+        kill_process()
+        print("Threat blocked.")
+    else:
+        print("No infection detected.")
+
+
+if __name__ == "__main__":
+    scan_and_block()

--- a/frontend/src/components/Timeline.jsx
+++ b/frontend/src/components/Timeline.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function Timeline({ logs = [] }) {
+  return (
+    <ul className="border-r-2 border-gray-400 pr-4 space-y-1 text-sm">
+      {logs.map((log, idx) => (
+        <li key={idx} className="flex items-start gap-2">
+          <span className="text-gray-400">{log.time}</span>
+          <span>{log.msg}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/pages/Practice.js
+++ b/frontend/src/pages/Practice.js
@@ -1,5 +1,6 @@
 // עמוד תרגול מעשי - React עם ממשק מותאם אישית (רשימת משימות וחלונית הסבר)
 import { useState } from 'react';
+import Timeline from '../components/Timeline';
 import axios from 'axios';
 
 const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
@@ -13,7 +14,7 @@ const TASKS = [
     tools: [
       'הקובץ trigger_ransom.py ממוקם ב־/tmp/data',
       'האנטי וירוס שלך רץ ברקע כל הזמן',
-      'זיהוי מוצלח כותב BLOCKED לקובץ /tmp/block_ransom'
+      'לאחר זיהוי השתמש בפונקציה kill_process כדי לעצור את התהליך'
     ]
   },
   {
@@ -23,7 +24,7 @@ const TASKS = [
       'הכופרה מצפינה את תחילת הקובץ (10KB) עם מפתח AES. מטרתך למנוע את פעולת ההצפנה לפני שמתרחש שינוי בפועל לקובץ.',
     tools: [
       'הצפנה מתבצעת גם היא על קבצים ב־/tmp/data',
-      'אם זיהית ניסיון הצפנה – עצור את התהליך וכתוב קובץ חסימה'
+      'אם זיהית ניסיון הצפנה – עצור את התהליך בעזרת kill_process'
     ]
   },
   {
@@ -44,9 +45,18 @@ export default function PracticeExercise() {
   const [showToolbox, setShowToolbox] = useState(false);
   const [detected, setDetected] = useState(null);
   const [blocked, setBlocked] = useState(null);
+  const [logs, setLogs] = useState([]);
+  const [taskStatus, setTaskStatus] = useState({});
   const [currentTask, setCurrentTask] = useState('infection');
 
   const currentTaskData = TASKS.find(task => task.id === currentTask);
+
+  const getStatusText = status => {
+    if (!status) return '⬜ לא בוצעה';
+    if (status.detected && status.blocked) return '🟢 בוצעה בהצלחה';
+    if (status.detected && !status.blocked) return '🟡 זוהה, לא נחסם';
+    return '⬜ לא בוצעה';
+  };
 
   const runAntivirus = async () => {
     try {
@@ -55,10 +65,12 @@ export default function PracticeExercise() {
       setOutput(res.data.result || res.data.error || '');
       setDetected(null);
       setBlocked(null);
+      setLogs([]);
     } catch {
       setOutput('❌ שגיאה בהרצה');
       setDetected(null);
       setBlocked(null);
+      setLogs([]);
     }
   };
 
@@ -69,10 +81,13 @@ export default function PracticeExercise() {
       setOutput(res.data.stdout || res.data.stderr || '');
       setDetected(res.data.detected);
       setBlocked(res.data.blocked);
+      setLogs(res.data.logs || []);
+      setTaskStatus(prev => ({ ...prev, [currentTask]: { detected: res.data.detected, blocked: res.data.blocked } }));
     } catch {
       setOutput('❌ שגיאה בהרצה');
       setDetected(null);
       setBlocked(null);
+      setLogs([]);
     }
   };
 
@@ -98,16 +113,20 @@ export default function PracticeExercise() {
               setOutput('');
               setDetected(null);
               setBlocked(null);
+              setLogs([]);
             }}
             className={`px-4 py-2 rounded shadow text-white ${currentTask === task.id ? 'bg-blue-600' : 'bg-slate-700 hover:bg-slate-600'}`}
           >
-            {task.label}
+            {task.label} ({getStatusText(taskStatus[task.id])})
           </button>
         ))}
       </div>
 
       {/* תיאור המשימה הנבחרת */}
-      <div className="bg-slate-800 rounded p-4 text-sm">
+      <div className="bg-slate-800 rounded p-4 text-sm space-y-2">
+        <h2 className="text-lg font-semibold">
+          {currentTaskData.label} ({getStatusText(taskStatus[currentTask])})
+        </h2>
         <p><span className="font-bold">🧠 משימה:</span> {currentTaskData.description}</p>
       </div>
 
@@ -141,13 +160,13 @@ export default function PracticeExercise() {
           onClick={runAntivirus}
           className="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded text-lg shadow"
         >
-          ▶️ הרץ אנטי וירוס
+          🛡️ הפעל אנטי־וירוס בלבד
         </button>
         <button
           onClick={runSimulation}
           className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded text-lg shadow"
         >
-          ▶️ הפעל סימולציה
+          🚀 הפעל סימולציה מלאה
         </button>
       </div>
 
@@ -158,11 +177,19 @@ export default function PracticeExercise() {
             {output}
           </pre>
           {detected !== null && (
-            <div className="space-y-1 text-xl">
-              <p>{detected ? '✅ זיהוי הצליח' : '❌ זיהוי נכשל'}</p>
+            <div className={`p-4 rounded space-y-1 text-xl ${detected && blocked ? 'bg-green-900' : 'bg-red-900'}`}> 
+              <p>{detected ? '✅ זיהוי התהליך הצליח!' : '❌ לא זוהה התהליך החשוד.'}</p>
               {detected && (
-                <p>{blocked ? '🔒 חסימה הצליחה' : '🔓 חסימה נכשלה'}</p>
+                <p>{blocked ? '🟢 התהליך הזדוני נחסם בהצלחה!' : '🔴 התהליך הזדוני לא נחסם!'}</p>
               )}
+            </div>
+          )}
+          {logs.length > 0 && (
+            <Timeline logs={logs} />
+          )}
+          {detected !== null && (!detected || (detected && !blocked)) && (
+            <div className="bg-yellow-900 p-2 rounded text-sm">
+              { !detected ? 'הטיפ שלנו: ודא שהאנטי־וירוס שלך סורק תהליכים בזמן אמת.' : 'הטיפ שלנו: קרא לפונקציה kill_process מיד כשזיהית.'}
             </div>
           )}
         </div>

--- a/frontend/src/pages/Summary.js
+++ b/frontend/src/pages/Summary.js
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 import "./styles/Summary.css";
 
+const TASK_LABELS = {
+  infection: "🧬 חסימת הדבקה",
+  encrypt: "🔐 מניעת הצפנה",
+  decrypt: "🗝️ פענוח קבצים",
+};
+
 const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
 
 const Summary = () => {
@@ -11,7 +17,8 @@ const Summary = () => {
   quiz_score: 0,
   simulations_blocked: [],
   detection_accuracy: 0,
-  theory_progress_percent: 0
+  theory_progress_percent: 0,
+  task_results: {}
 });
 
   useEffect(() => {
@@ -61,6 +68,22 @@ const Summary = () => {
               <span>🎯 אחוז דיוק בזיהוי:</span>
               <span>{stats.detection_accuracy}%</span>
             </div>
+            {stats.task_results && (
+              <div className="summaryItem">
+                <span>📋 סטטוס משימות:</span>
+                <ul className="list-disc pr-5">
+                  {Object.entries(TASK_LABELS).map(([id, label]) => {
+                    const res = stats.task_results[id] || {};
+                    let txt = '⬜ לא בוצעה';
+                    if (res.detected && res.blocked) txt = '🟢 בוצעה בהצלחה';
+                    else if (res.detected && !res.blocked) txt = '🟡 זוהה, לא נחסם';
+                    return (
+                      <li key={id}>{label} - {txt}</li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add `kill_process` helper that terminates a PID and creates the block flag
- document the helper in README and update default antivirus snippet
- revise standalone AV example scripts to use `kill_process`
- update practice instructions and tips about blocking

## Testing
- `pip install -q Flask flask_cors pycryptodome psutil`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459f1111f48328bd8a878c6f869b8f